### PR TITLE
Agregando socket manualmente y reparación de bug al escoger el puerto de mysql

### DIFF
--- a/www/config/config.database.php.example.php
+++ b/www/config/config.database.php.example.php
@@ -1,4 +1,5 @@
 <?php
+/* ex: set tabstop=2 noexpandtab: */
 /**
  * Access from index.php:
  */
@@ -18,8 +19,9 @@ if($production) {
 	define("_dbUser", "root"); 
 	define("_dbPwd", "");
 	define("_dbName", "YOUR DATABASE");
-	define("_dbPort", "5432");
+	define("_dbPort", "3306");
 	define("_dbPfx", "zan_");
+	define("_dbSocket", NULL);
 	
 	//NoSQL Settings
 	define("_dbNoSQLHost", "localhost");
@@ -34,8 +36,9 @@ if($production) {
 	define("_dbUser", "root2"); 
 	define("_dbPwd", "");
 	define("_dbName", "zanphp");
-	define("_dbPort", "5432");
+	define("_dbPort", "3306");
 	define("_dbPfx", "zan_");
+	define("_dbSocket", NULL);
 	
 	//NoSQL Settings
 	define("_dbNoSQLHost", "localhost");

--- a/zan/classes/class.mysqli_db.php
+++ b/zan/classes/class.mysqli_db.php
@@ -1,4 +1,5 @@
 <?php
+/* ex: set tabstop=2 noexpandtab: */
 /**
  * ZanPHP
  *
@@ -53,7 +54,7 @@ class ZP_MySQLi_Db extends ZP_Load {
      */
 	public function connect() {
 		if(self::$connection === NULL) {
-			self::$connection = mysqli_connect(_dbHost, _dbUser, _dbPwd, _dbName);
+			self::$connection = mysqli_connect(_dbHost, _dbUser, _dbPwd, _dbName, _dbPort, _dbSocket);
 		}
 		
 		return self::$connection;


### PR DESCRIPTION
Hola.

agregue una constante para poder definir un socket distinto al que viene
por default (para instalaciones exoticas) también reparé un
pequeño bug que apesar de poder escoger el puerto de mysql en la
configuración esta opción no era tomada en cuenta en la clase mysqli_db

Saludos. 
