### PR TITLE
Autorender para las acciones de los controladores

### DIFF
--- a/zan/classes/class.controller.php
+++ b/zan/classes/class.controller.php
@@ -1,4 +1,5 @@
 <?php
+/* ex: set tabstop=2 noexpandtab: */
 /**
  * ZanPHP
  *
@@ -47,6 +48,12 @@ class ZP_Controller extends ZP_Load {
 		$helpers = array("alerts", "debugging", "time", "string", "forms", "security");
 		
 		$this->helper($helpers);	
+	}
+
+	public function afterFinish() {
+		if( $this->autoRender ) {
+			$this->render();
+		}
 	}
 	
 }

--- a/zan/classes/class.load.php
+++ b/zan/classes/class.load.php
@@ -54,6 +54,8 @@ class ZP_Load {
 	 */
 	public $Templates;
 	
+	var $autoRender = TRUE;
+	
 	/**
 	 * Contains the array of views
 	 * 
@@ -573,6 +575,7 @@ class ZP_Load {
 			
 			$this->right();
 			$this->footer();
+			$this->autoRender = false;
 		}
 	}
 	

--- a/zan/helpers/helper.router.php
+++ b/zan/helpers/helper.router.php
@@ -1,4 +1,5 @@
 <?php
+/* ex: set tabstop=2 noexpandtab: */
 /**
  * ZanPHP
  *
@@ -162,7 +163,7 @@ function execute() {
 		
 		$$controller = $Load->controller($controller);
 	}
-	
+
 	if(file_exists($controllerFile)) {
 		if(isset($method) and isset($params)) { 
 			if(method_exists($$controller, $method)) {
@@ -218,6 +219,7 @@ function execute() {
 		} else {
 			$$controller->index();	
 		}
+		$$controller->afterFinish();
 	}
 }
 


### PR DESCRIPTION
Este es un cambio que les vengo a proponer para ZanPHP  cualquier feedback es aceptado quiza algo que  cambiar o pulir antes de combinar el cambio o alguna razón por la que zanphp no necesita esto su core  esta bien.

Ahora si les explico.

La mayoría de las veces las acciones en los controladores de ZanPHP imprimen algo en pantalla (normalmente usando una  vista), por ejemplo esta el controlador users de la aplicación users que ustedes tienen en el repositorio todas esas acciones (métodos) terminan con 

``` php
<?php
  $this->render();
?>
```

Lo mismo pasa con el controlador blog. 

básicamente la idea es que esta función sea llamada automaticamente, es decir, que si no ha sido invocada manualmente  entonces que zanphp la ejecute. por ejemplo la acción register de la aplicación users quedaría así: 

``` php
<?php   
  public function register() {
    if(POST("save")) {
      $vars["alert"] = $this->Users_Model->register();
    }

    $vars["view"] = $this->view("register", TRUE);          
    $this->template("content", $vars);

    //Aquí normalmente iba $this->render(); pero ahora se ejecuta 
    // automaticamente y no es necesario
  }
?>
```

Ahora, ustedes se preguntarán que pasa con esas funciones que no queremos que haga un $this->render(); sino que simplemente no imprima nada en absoluto. pues podemos "apagar" este autorender cuando queramos:

``` php
<?php 
  public function register() {
    $this->autoRender = FALSE;

    //Ahora no se ejecutará  $this->render(); automaticamente
  }
?>
```

De esta forma le estamos ahorrando al usuario repetir la misma línea de código cada vez todas las veces por cada acción de Zanphp (queda mas acorde con el principio DRY) y al mismo tiempo no le estamos quitando control sobre la app por que el puede _apagar_ este comportamiento cuando quiera.
