### PR TITLE
Evitar que el programador tenga que borrar los headers que previenen el ...

### DIFF
--- a/www/load.php
+++ b/www/load.php
@@ -22,6 +22,13 @@ if($ZP["production"]) {
 
 	ini_set("display_errors", FALSE); 
 } else {
+	if ( ! headers_sent() )
+	{
+		header("Cache-Control: no-cache, must-revalidate");
+		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT"); 
+		header("Content-type: text/html; charset=utf-8");
+	}
+	
 	error_reporting(E_ALL);
 }
 
@@ -51,11 +58,6 @@ if(get("translation") === "gettext") {
 
 benchMarkStart();
 
-header("Cache-Control: no-cache, must-revalidate");
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT"); 
-header("Content-type: text/html; charset=utf-8");
-
-error_reporting(E_ALL);
 
 if(!version_compare(PHP_VERSION, "5.1.0", ">=")) {
 	die("ZanPHP needs PHP 5.1.X or higher to run.");


### PR DESCRIPTION
...caché del navegador haciendo que solamente esté habilitado cuando se está en modo desarrollo
