### PR TITLE
Error en función getWhere

### DIFF
--- a/zan/classes/db.php
+++ b/zan/classes/db.php
@@ -492,9 +492,10 @@ class ZP_Db extends ZP_Load
 	}
 	
 	public function getWhere($table, $where, $limit = 0, $offset = 0)
-	{		
+	{	
+		$_where = '';	
 		foreach ($where as $field => $value) {
-			$_where = "$field = '$value' AND ";
+			$_where .= "$field = '$value' AND ";
 		}
 		
 		$_where = rtrim($_where, "AND ");


### PR DESCRIPTION
Linea 497: Al momento de que se abre el ciclo se declara en cada iteración la variable $_where y al final solo contendrá el ultimo WHERE de la consulta.

SOLUCIÓN: Se crea la variable $_where fuera del Foreach y se concatena la información del arreglo $where en cada iteración.
